### PR TITLE
Ajout configuration 'test' pour envrionement de dev

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,6 +36,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                         ->scalarNode('base_url')->info('Url Api endpoint')->isRequired()->end()
+                        ->scalarNode('test')->defaultValue(false)
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/WannaSpeakExtension.php
+++ b/DependencyInjection/WannaSpeakExtension.php
@@ -36,5 +36,6 @@ class WannaSpeakExtension extends Extension
         $container->setParameter('wanna_speak.api.account_id', $config['api']['credentials']['account_id']);
         $container->setParameter('wanna_speak.api.secret_key', $config['api']['credentials']['secret_key']);
         $container->setParameter('wanna_speak.api.base_url', $config['api']['base_url']);
+        $container->setParameter('wanna_speak.api.test', $config['api']['test']);
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,6 +14,7 @@
             <argument>%wanna_speak.api.account_id%</argument>
             <argument>%wanna_speak.api.secret_key%</argument>
             <argument>%wanna_speak.api.base_url%</argument>
+            <argument>%wanna_speak.api.test%</argument>
         </service>
 
         <service id="wanna_speak.main.guzzle.client" class="%guzzle.client.class%">


### PR DESCRIPTION
La variable de config 'test' permet de ne pas appeler l'API wannaSpeak si on ne veut pas.
(on ne supprime et n'ajoute plus de numéros)
