### PR TITLE
fix(http-client): prevent multiple authentication plugins

### DIFF
--- a/Api/WannaSpeakHttpClient.php
+++ b/Api/WannaSpeakHttpClient.php
@@ -108,12 +108,10 @@ class WannaSpeakHttpClient
     protected function getHttpClient()
     {
         if ($this->httpClient === null) {
-            $this->httpClient = HttpClientDiscovery::find();
+            $authentication       = new QueryParam(['key' => $this->getAuthKey()]);
+            $authenticationPlugin = new AuthenticationPlugin($authentication);
+            $this->httpClient     = new PluginClient(HttpClientDiscovery::find(), [$authenticationPlugin]);
         }
-
-        $authentication       = new QueryParam(['key' => $this->getAuthKey()]);
-        $authenticationPlugin = new AuthenticationPlugin($authentication);
-        $this->httpClient     = new PluginClient($this->httpClient, [$authenticationPlugin]);
 
         return $this->httpClient;
     }


### PR DESCRIPTION
Si la méthode `getHttpClient()` était appelée deux fois, ça créait un nouvel `PluginClient` à chaque fois.

On pouvait donc avoir un `PluginClient` qui modifiait un `PluginClient`, qui modifiait un `PluginClient`, qui modifiait un `PluginClient`, etc ...