### PR TITLE
fix(http-client): prevent "Time not sync" error

### DIFF
--- a/Api/Statistics.php
+++ b/Api/Statistics.php
@@ -76,7 +76,10 @@ class Statistics implements StatisticsInterface
         $data = json_decode($response->getBody()->getContents(), true);
 
         if ($data['error']) {
-            throw new \Exception('WannaSpeak API: '.$data['error']['txt']);
+            throw new \Exception(sprintf(
+                'WannaSpeak API: %s',
+                is_array($data['error']) ? $data['error']['txt'] : $data['error']
+            ));
         }
 
         return $data;

--- a/Api/WannaSpeakHttpClient.php
+++ b/Api/WannaSpeakHttpClient.php
@@ -107,15 +107,12 @@ class WannaSpeakHttpClient
      */
     protected function getHttpClient()
     {
-        if ($this->httpClient === null) {
-            $this->httpClient = HttpClientDiscovery::find();
-        }
+        $client = $this->httpClient !== null ? $this->httpClient : HttpClientDiscovery::find();
 
         $authentication       = new QueryParam(['key' => $this->getAuthKey()]);
         $authenticationPlugin = new AuthenticationPlugin($authentication);
-        $this->httpClient     = new PluginClient($this->httpClient, [$authenticationPlugin]);
 
-        return $this->httpClient;
+        return new PluginClient($client, [$authenticationPlugin]);
     }
 
     /**


### PR DESCRIPTION
I think the auth key was not properly regenerated, because after some time we got `Time not sync` error
