### PR TITLE
Ajout du code d'erreur aux exceptions lancées par Api/Statistics::processResponse()

### DIFF
--- a/Api/Statistics.php
+++ b/Api/Statistics.php
@@ -76,10 +76,10 @@ class Statistics implements StatisticsInterface
         $data = json_decode($response->getBody()->getContents(), true);
 
         if ($data['error']) {
-            throw new \Exception(sprintf(
-                'WannaSpeak API: %s',
-                is_array($data['error']) ? $data['error']['txt'] : $data['error']
-            ));
+            $message = sprintf('WannaSpeak API: %s',is_array($data['error']) ? $data['error']['txt'] : $data['error']);
+            $code    = $data['error']['nb'];
+
+            throw new \Exception($message, $code);
         }
 
         return $data;


### PR DESCRIPTION
Nécessaire pour [YPROX-5663](https://yproximite.atlassian.net/browse/YPROX-5663)