### PR TITLE
fix(statistics): check if data['error'] is not null, since it always included in the response...

### DIFF
--- a/src/Api/Statistics.php
+++ b/src/Api/Statistics.php
@@ -61,7 +61,7 @@ class Statistics implements StatisticsInterface
     {
         $data = json_decode($response->getBody()->getContents(), true);
 
-        if (is_array($data) && array_key_exists('error', $data)) {
+        if (is_array($data) && array_key_exists('error', $data) && null !== $data['error']) {
             $error = is_array($data['error']) ? $data['error']['txt'] : $data['error'];
             throw new \Exception(sprintf('WannaSpeak API: %s', $error));
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2103975/98227752-f4867380-1f57-11eb-8b8c-3309cf2c42b2.png)
