### PR TITLE
fix(http-client): send all request parameters as "query" parameter

### DIFF
--- a/spec/Yproximite/WannaSpeakBundle/Api/SoundsSpec.php
+++ b/spec/Yproximite/WannaSpeakBundle/Api/SoundsSpec.php
@@ -47,9 +47,9 @@ class SoundsSpec extends ObjectBehavior
             ->request(
                 SoundsInterface::API,
                 'upload',
+                ['name' => 'the name'],
                 Argument::that(function ($args) {
-                    return $args['sound'] instanceof DataPart
-                        && 'the name' === $args['name'];
+                    return $args['sound'] instanceof DataPart;
                 })
             )
             ->shouldBeCalled()
@@ -66,9 +66,9 @@ class SoundsSpec extends ObjectBehavior
             ->request(
                 SoundsInterface::API,
                 'upload',
+                ['name' => 'the name'],
                 Argument::that(function ($args) {
-                    return $args['sound'] instanceof DataPart
-                        && 'the name' === $args['name'];
+                    return $args['sound'] instanceof DataPart;
                 })
             )
             ->shouldBeCalled()

--- a/src/Api/Sounds.php
+++ b/src/Api/Sounds.php
@@ -31,12 +31,16 @@ class Sounds implements SoundsInterface
             throw new \InvalidArgumentException(sprintf('A string or an instance of "SplInfo" is required for uploading the file.'));
         }
 
-        $arguments = array_merge($additionalArguments, [
-            'sound' => DataPart::fromPath($path),
-            'name'  => $name,
-        ]);
-
-        $response = $this->client->request(self::API, 'upload', $arguments);
+        $response = $this->client->request(
+            self::API,
+            'upload',
+            array_merge($additionalArguments, [
+                'name' => $name,
+            ]),
+            [
+                'sound' => DataPart::fromPath($path),
+            ]
+        );
 
         return $response->toArray(); // @phpstan-ignore-line
     }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -82,7 +82,7 @@ class HttpClient implements HttpClientInterface
         $formData = new FormDataPart($body);
 
         $options = [
-            'query' => $query,
+            'query'   => $query,
             'headers' => $formData->getPreparedHeaders()->toArray(),
             'body'    => $formData->bodyToIterable(),
         ];
@@ -97,6 +97,11 @@ class HttpClient implements HttpClientInterface
         return $timeStamp.'-'.md5($this->accountId.$timeStamp.$this->secretKey);
     }
 
+    /**
+     * @param array<string,mixed> $parameters
+     *
+     * @return array<string,string>
+     */
     private function sanitizeParameters(array $parameters): array
     {
         return array_reduce(array_keys($parameters), static function (array $acc, string $fieldKey) use ($parameters) {
@@ -104,9 +109,9 @@ class HttpClient implements HttpClientInterface
 
             if (true === $fieldValue) {
                 $fieldValue = '1';
-            } else if (false === $fieldValue) {
+            } elseif (false === $fieldValue) {
                 $fieldValue = '0';
-            } else if (is_int($fieldValue)) {
+            } elseif (is_int($fieldValue)) {
                 $fieldValue = (string) $fieldValue;
             }
 

--- a/src/HttpClientInterface.php
+++ b/src/HttpClientInterface.php
@@ -11,8 +11,9 @@ interface HttpClientInterface
 {
     /**
      * @param array<string,mixed> $additionalArguments Additional WannaSpeak request arguments
+     * @param array<string,mixed> $body
      *
      * @throws TestModeException
      */
-    public function request(string $api, string $method, array $additionalArguments = []): ResponseInterface;
+    public function request(string $api, string $method, array $additionalArguments = [], array $body = []): ResponseInterface;
 }


### PR DESCRIPTION
Event if we use POST method...

C'est un peu incompréhensible mais bon, d'après Maryline il faut bien tout passer en paramètre GET et effectivement ça fonctionne : 
![image](https://user-images.githubusercontent.com/2103975/101154374-f3636780-3625-11eb-96dc-0dd262d4506f.png)
