### PR TITLE
fix(calltracking:expires): it seems that "name" is required now...

### DIFF
--- a/spec/Yproximite/WannaSpeakBundle/Api/CallTrackingsSpec.php
+++ b/spec/Yproximite/WannaSpeakBundle/Api/CallTrackingsSpec.php
@@ -131,6 +131,7 @@ class CallTrackingsSpec extends ObjectBehavior
                 'did'         => '33176280XXX',
                 'destination' => '33474123XXX',
                 'stopdate'    => '2020-11-19',
+                'name'        => 'Expired number.',
             ])
             ->shouldBeCalled()
             ->willReturn($response);

--- a/src/Api/CallTrackings.php
+++ b/src/Api/CallTrackings.php
@@ -70,6 +70,7 @@ class CallTrackings implements CallTrackingsInterface
             'did'         => $phoneDid,
             'destination' => $phoneDestination,
             'stopdate'    => $when->format('Y-m-d'),
+            'name'        => 'Expired number.',
         ]);
 
         $response = $this->client->request(self::API, 'modify', $arguments);


### PR DESCRIPTION
Following of #33, parameter `name` is required too... :roll_eyes: 

![image](https://user-images.githubusercontent.com/2103975/109824017-bc0e5200-7c38-11eb-99eb-1b5a9527a01d.png)


when passing a name, it's fine : 
![image](https://user-images.githubusercontent.com/2103975/109823939-aa2caf00-7c38-11eb-918a-8111e7867b3d.png)


...